### PR TITLE
chore: switch to bellpepper, correct dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,13 @@ documentation = "https://github.com/lurk-lab/circom-scotia/blob/main/README.md"
 readme = "README.md"
 repository = "https://github.com/lurk-lab/circom-scotia"
 license = "MIT OR Apache-2.0"
-license-file = "LICENSE"
 keywords = ["zkSNARKs", "cryptography", "proofs"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 anyhow = "1.0.65"
-bellperson = "0.25"
+bellpepper-core = "0.2.1"
 byteorder = "1.4.3"
 cfg-if = "1.0.0"
 color-eyre = "0.6.2"

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -1,12 +1,12 @@
-use bellperson::ConstraintSystem;
+use bellpepper_core::ConstraintSystem;
 use circom_scotia::{calculate_witness, r1cs::CircomConfig, synthesize};
 use ff::Field;
 
 use pasta_curves::vesta::Base as Fr;
 use std::env::current_dir;
 
-use bellperson::util_cs::test_cs::TestConstraintSystem;
-use bellperson::util_cs::Comparable;
+use bellpepper_core::test_cs::TestConstraintSystem;
+use bellpepper_core::Comparable;
 
 fn main() {
     let root = current_dir().unwrap().join("examples/sha256");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use std::{
     process::Command,
 };
 
-use bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, LinearCombination, SynthesisError};
+use bellpepper_core::{num::AllocatedNum, ConstraintSystem, LinearCombination, SynthesisError};
 use color_eyre::Result;
 use ff::PrimeField;
 use r1cs::{CircomConfig, R1CS};


### PR DESCRIPTION
NOTE: We should release this on crates-io.
(also, as cargo will indicate, only one of license OR license-file is needed)