### PR TITLE
release 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circom-scotia"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Hanting Zhang <winston@lurk-lab.com>"]
 description = "Middleware to compile Circom circuits to Bellperson"


### PR DESCRIPTION
I had already bumped to 0.1.1 earlier, and forgot to sync `Cargo.toml`. 
```
➜  circom-scotia git:(main) cargo release patch --execute
error: uncommitted changes detected, please resolve before release:
```
I got this error when I attempted to bump again, and realized I forgot, and now am fixing (hopefully this is the right way to do this).