### PR TITLE
chore: make circom-scotia depend on released version of bellpepper-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version="1.70.0"
 
 [dependencies]
 anyhow = "1.0.65"
-bellpepper-core = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev" }
+bellpepper-core = { version = "0.4.0" }
 byteorder = "1.4.3"
 cfg-if = "1.0.0"
 crypto-bigint = { version = "0.5.2", features = ["serde"] }


### PR DESCRIPTION
This PR needs no companion PR, as it it not used upstream except in https://github.com/lurk-lab/lurk-rs/pull/997