### PR TITLE
chore: Update bellpepper-core dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["zkSNARKs", "cryptography", "proofs"]
 
 [dependencies]
 anyhow = "1.0.65"
-bellpepper-core = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev" }
+bellpepper-core = { version = "0.4.0" }
 byteorder = "1.4.3"
 cfg-if = "1.0.0"
 color-eyre = "0.6.2"


### PR DESCRIPTION
- Updated the `bellpepper-core` dependency in Cargo.toml
- Changed the dependency source from `dev` branch on GitHub to the stable release `0.4.0`

This will need a companion PR downstream:
- [x] lurk: https://github.com/lurk-lab/lurk-rs/pull/1157