### PR TITLE
chore: Switch to `ruint`, cleanup conversion functions and add tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.65"
 bellpepper-core = { version = "0.4.0" }
 byteorder = "1.4.3"
 cfg-if = "1.0.0"
-crypto-bigint = { version = "0.5.2", features = ["serde"] }
+ruint = { version = "1.12.0", features = ["serde", "rand"] }
 ff = { version = "0.13", features = ["derive"] }
 fnv = "1.0.7"
 itertools = "0.9.0"
@@ -38,6 +38,7 @@ getrandom = { version = "0.2.10", features = ["js"] }
 [dev-dependencies]
 pasta_curves = { version = "0.5.1" }
 criterion = { version = "0.5" }
+rand = "0.8.5"
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ use std::process::Command;
 pub mod error;
 pub mod r1cs;
 pub mod reader;
+mod util;
 pub mod witness;
 
 /// Generates a witness file from a given WebAssembly (WASM) binary using a JSON input.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ use crate::r1cs::CircomInput;
 use crate::reader::load_witness_from_file;
 use anyhow::Result;
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem, LinearCombination, SynthesisError};
-use ff::PrimeField;
+use ff::{PrimeField, PrimeFieldBits};
 use log::{error, info, warn};
 use r1cs::{CircomConfig, R1CS};
 use std::env::current_dir;
@@ -159,7 +159,7 @@ pub fn generate_witness_from_wasm<F: PrimeField>(
 /// let inputs: Vec<CircomInput<Fr>> = vec![CircomInput::new(String::from("input_name"), vec![Fr::ZERO])];
 /// let result = calculate_witness::<Fr>(&cfg, inputs, true);
 /// ```
-pub fn calculate_witness<F: PrimeField>(
+pub fn calculate_witness<F: PrimeFieldBits>(
     cfg: &CircomConfig<F>,
     input: Vec<CircomInput<F>>,
     sanity_check: bool,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -296,10 +296,13 @@ fn read_header<R: Read>(
         .read_exact(&mut prime_size)
         .map_err(|err| ReadBytesError { source: err.into() })?;
     let prime = U256::from_le_slice(&prime_size);
-    let prime = &prime.to_string().to_ascii_lowercase();
 
-    if prime != &expected_prime[2..] {
-        // get rid of '0x' in the front
+    let expected_prime =
+        U256::from_str_radix(&expected_prime[2..], 16).map_err(|_err| NonMatchingPrime {
+            expected: expected_prime.to_string(),
+            value: prime.to_string(),
+        })?;
+    if prime != expected_prime {
         return Err(NonMatchingPrime {
             expected: expected_prime.to_string(),
             value: prime.to_string(),

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -8,8 +8,8 @@
 //! constraints.
 
 use anyhow::{anyhow, Context, Error, Result};
-use crypto_bigint::U256;
 use ff::PrimeField;
+use ruint::aliases::U256;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -261,7 +261,7 @@ fn read_field<R: Read, F: PrimeField>(mut reader: R) -> Result<F, Error> {
 
     let fr = F::from_repr(repr);
 
-    if <crypto_bigint::subtle::Choice as Into<bool>>::into(fr.is_some()) {
+    if fr.is_some().into() {
         #[allow(clippy::unwrap_used)]
         Ok(fr.unwrap())
     } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,92 @@
+use std::mem::transmute;
+
+use ff::PrimeField;
+use ruint::aliases::U256;
+
+/// Assumes little endian
+pub fn u256_as_limbs(uint: &U256) -> &[u32; 8] {
+    let limbs = uint.as_limbs();
+    unsafe { transmute(limbs) }
+}
+
+/// Assumes little endian
+pub fn limbs_as_u256(limbs: [u32; 8]) -> U256 {
+    let limbs: [u64; 4] = unsafe { transmute(limbs) };
+    U256::from_limbs(limbs)
+}
+
+/// Assumes little endian
+pub fn ff_as_limbs<F: PrimeField>(f: &F) -> &[u32; 8] {
+    let binding = f.to_repr();
+    let repr: &[u8; 32] = binding.as_ref().try_into().unwrap();
+    // this doesn't work if the platform we're on is not little endian :scream:
+    unsafe { transmute(repr) }
+}
+
+/// Assumes little endian
+pub fn limbs_as_ff<F: PrimeField>(limbs: [u32; 8]) -> F {
+    let mut repr = F::ZERO.to_repr();
+    let limbs: [u8; 32] = unsafe { transmute(limbs) };
+    for (i, digit) in repr.as_mut().iter_mut().enumerate() {
+        // this doesn't work if the platform we're on is not little endian :scream:
+        *digit = limbs[i];
+    }
+
+    F::from_repr(repr).unwrap()
+}
+
+/// Assumes little endian
+pub fn u256_as_ff<F: PrimeField>(uint: &U256) -> F {
+    limbs_as_ff(*u256_as_limbs(uint))
+}
+
+#[allow(unused)]
+/// Assumes little endian
+pub fn ff_as_u256<F: PrimeField>(f: &F) -> U256 {
+    limbs_as_u256(*ff_as_limbs(f))
+}
+
+#[cfg(test)]
+mod tests {
+    use ff::Field;
+    use pasta_curves::pallas;
+    use rand::Rng;
+    use ruint::aliases::U256;
+
+    use super::*;
+
+    #[test]
+    fn test_u256_limb_roundtrip() {
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..100 {
+            let uint = rng.gen::<U256>();
+            let limbs = u256_as_limbs(&uint);
+            let other_uint = limbs_as_u256(*limbs);
+            assert_eq!(uint, other_uint)
+        }
+    }
+
+    #[test]
+    fn test_ff_limb_roundtrip() {
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..100 {}
+        let f = pallas::Scalar::random(&mut rng);
+        let limbs = ff_as_limbs(&f);
+        let other_f = limbs_as_ff(*limbs);
+        assert_eq!(f, other_f)
+    }
+
+    #[test]
+    fn test_u256_ff_roundtrip() {
+        let mut rng = rand::thread_rng();
+
+        for _ in 0..100 {
+            let f = pallas::Scalar::random(&mut rng);
+            let uint = ff_as_u256(&f);
+            let other_f = u256_as_ff(&uint);
+            assert_eq!(f, other_f)
+        }
+    }
+}

--- a/src/witness/error.rs
+++ b/src/witness/error.rs
@@ -2,8 +2,4 @@ use thiserror::Error;
 
 /// Enum related to witness generatiuon problems.
 #[derive(Error, Debug)]
-pub enum WitnessCalculatorError {
-    /// Error thrown when aligning over 64-bits fails on a target architecture of 64-bit.
-    #[error("Unaligned parts after aligning over 64-bit pointer.")]
-    UnalignedParts,
-}
+pub enum WitnessCalculatorError {}

--- a/src/witness/memory.rs
+++ b/src/witness/memory.rs
@@ -171,7 +171,7 @@ impl SafeMemory {
 
         if view[ptr + 7] & 0x80 != 0 {
             let num = self.read_big(store, ptr + 8);
-            u256_as_ff(&num)
+            u256_as_ff(num)
         } else {
             F::from(u64::from(self.read_u32(store, ptr)))
         }
@@ -186,7 +186,7 @@ impl SafeMemory {
     /// * `ptr` - The memory address where the field element will be written.
     /// * `fr` - The [`U256`] field element to write.
     fn write_short(&mut self, store: &impl AsStoreRef, ptr: usize, fr: U256) -> Result<()> {
-        let num = fr.as_limbs()[0] as u32; // wtf is happening
+        let num = fr.as_limbs()[0] as u32;
         self.write_u32(store, ptr, num);
         self.write_u32(store, ptr + 4, 0);
         Ok(())

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -178,7 +178,7 @@ impl WitnessCalculator {
             let (msb, lsb) = fnv(&input.name);
 
             for (i, value) in input.value.into_iter().enumerate() {
-                let f_arr = ff_as_limbs(&value);
+                let f_arr = ff_as_limbs(value);
                 for j in 0..n32 {
                     self.instance
                         .write_shared_rw_memory(&mut self.store, j, f_arr[j as usize])?;
@@ -195,8 +195,7 @@ impl WitnessCalculator {
             self.instance.get_witness(&mut self.store, i)?;
             let mut arr = [0; 8];
             for j in 0..n32 {
-                arr[(n32 as usize) - 1 - (j as usize)] =
-                    self.instance.read_shared_rw_memory(&mut self.store, j)?;
+                arr[j as usize] = self.instance.read_shared_rw_memory(&mut self.store, j)?;
             }
             w.push(limbs_as_ff(arr));
         }

--- a/src/witness/witness_calculator.rs
+++ b/src/witness/witness_calculator.rs
@@ -21,7 +21,7 @@
 //! and their byte representations, as well as the `runtime` submodule, which provides callback
 //! hooks for debugging and error handling within the WebAssembly environment.
 use anyhow::Result;
-use ff::PrimeField;
+use ff::PrimeFieldBits;
 use ruint::aliases::U256;
 use wasmer::{
     imports, AsStoreMut, Function, Instance, Memory, MemoryType, Module, RuntimeError, Store,
@@ -159,7 +159,7 @@ impl WitnessCalculator {
     /// # Errors
     ///
     /// Returns an error if the witness calculation fails.
-    pub fn calculate_witness<F: PrimeField>(
+    pub fn calculate_witness<F: PrimeFieldBits>(
         &mut self,
         inputs: Vec<CircomInput<F>>,
         sanity_check: bool,


### PR DESCRIPTION
This PR swtiches the bignum crate from `crypto-bigint` to `ruint`. The motivation for this particular switch is because https://github.com/philsippl/circom-witness-rs/tree/master uses `ruint`. After considering whether to switch to `ruint` or stay with `crypto-bigint` and port the code from `circom-witness-rs`, I decided `ruint` is a bit easier to work with. 

After making the switch, I cleaned up the `from_vec_u32`, etc, conversion functions into a utils module with tests for safety.