### PR TITLE
Fix output size in `synthesize`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ pub fn synthesize<F: PrimeField, CS: ConstraintSystem<F>>(
     let output = match r1cs.num_pub_out {
         0 => vec![],
         1 => vec![vars[0].clone()],
-        _ => vars[0..r1cs.num_pub_out - 1usize].to_vec(),
+        _ => vars[0..r1cs.num_pub_out].to_vec(),
     };
 
     // Create closure responsible to create the linear combination data.


### PR DESCRIPTION
## Goal

This PR fixes a bug that happens while getting the output from the witness. Currently we were missing one of them as we were iterating to `length - 1` instead of `length`.